### PR TITLE
Fix a couple cache errors

### DIFF
--- a/mixins/Category.lua
+++ b/mixins/Category.lua
@@ -4,13 +4,13 @@ local MIN_INDEX = 1
 local function defaultSort(slotA, slotB)
 	if(not slotA or not slotB) then
 		return slotA or slotB
-	elseif(slotA.itemQuality ~= slotB.itemQuality) then
+	elseif(slotA:GetItemQuality() ~= slotB:GetItemQuality()) then
 		return slotA.itemQuality > slotB.itemQuality
-	elseif(slotA.itemLevel ~= slotB.itemLevel) then
+	elseif(slotA:GetItemLevel() ~= slotB:GetItemLevel()) then
 		return slotA.itemLevel > slotB.itemLevel
-	elseif(slotA.itemID ~= slotB.itemID) then
+	elseif(slotA:GetItemID() ~= slotB:GetItemID()) then
 		return slotA.itemID > slotB.itemID
-	elseif(slotA.itemCount ~= slotB.itemCount) then
+	elseif(slotA:GetItemCount() ~= slotB:GetItemCount()) then
 		return slotA.itemCount > slotB.itemCount
 	else
 		return slotA:GetID() > slotB:GetID()

--- a/mixins/Item.lua
+++ b/mixins/Item.lua
@@ -46,8 +46,8 @@ Returns the non-empty Item's identifier.
 --]]
 function itemMixin:GetItemID()
 	if(not self:IsItemEmpty()) then
-		if(self.itemID == nil) then
-			self:CacheItemInfo()
+		if(not self.itemID) then
+			self.itemID = C_Item.GetItemID(self:GetItemLocation())
 		end
 
 		return self.itemID


### PR DESCRIPTION
I did some cursory tests and got a couple errors that seem to be due to an incomplete or out of date cache. More info on the specific cases in the commit messages.

The first commit fixes this error:
``` lua
x1  ...ddOns\Backpack\libs\LibContainer\mixins/Category.lua:10: attempt to compare nil with number
Stack: ...ddOns\Backpack\libs\LibContainer\mixins/Category.lua:10: in function <...ddOns\Backpack\libs\LibContainer\mixins/Category.lua:4>
[C] in function 'sort'
...dOns\Backpack\libs\LibContainer\mixins/Container.lua:79: in function 'UpdateSlotPositions'
...dOns\Backpack\libs\LibContainer\mixins/Container.lua:66: in function 'UpdateSize'
...dOns\Backpack\libs\LibContainer\mixins/Container.lua:359: in function 'UpdateContainers'
...\Backpack\libs\LibContainer\mixins/Parent.lua:66: in function <...\Backpack\libs\LibContainer\mixins/Parent.lua:56>
[C] in function 'securecall'
...e\Backpack\libs\LibContainer\mixins/Event.lua:49: in function <...e\Backpack\libs\LibContainer\mixins/Event.lua:45>
```

The second fixes this error:
``` lua
x1  ...ce\Backpack\libs\LibContainer\mixins/Item.lua:251: Usage: GetItemInfoInstant(itemID|"name"|"itemlink")
Stack: [C] in function 'GetItemInfoInstant'
...ce\Backpack\libs\LibContainer\mixins/Item.lua:251: in function 'CacheItemInfoInstant'
...ce\Backpack\libs\LibContainer\mixins/Item.lua:211: in function 'GetItemClass'
Backpack\Backpack-@project-version@.lua:25: in function 'Update'
...ce\Backpack\libs\LibContainer\mixins/Slot.lua:24: in function 'UpdateVisibility'
...ace\Backpack\libs\LibContainer\mixins/Bag.lua:19: in function 'UpdateSlots'
...\Backpack\libs\LibContainer\mixins/Parent.lua:60: in function <...\Backpack\libs\LibContainer\mixins/Parent.lua:56>
[C] in function 'securecall'
...e\Backpack\libs\LibContainer\mixins/Event.lua:49: in function <...e\Backpack\libs\LibContainer\mixins/Event.lua:45>
```